### PR TITLE
Fix C++11 and higher builds if __clang__ is defined

### DIFF
--- a/include/cy_utils.h
+++ b/include/cy_utils.h
@@ -172,7 +172,7 @@ void CY_ASSERT_HANDLER(void);
 #elif defined (__GNUC__)
     #if defined (__clang__)
         #define CY_NOINIT           __attribute__ ((section("__DATA, __noinit")))
-        #define CY_SECTION(name)    __attribute__ ((section("__DATA, "name)))
+        #define CY_SECTION(name)    __attribute__ ((section("__DATA, " name)))
         #define CY_RAMFUNC_BEGIN    __attribute__ ((section("__DATA, .cy_ramfunc")))
         #define CY_RAMFUNC_END
     #else


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
This fixes an error that happens when the code should be compiled with c++11 or newer and __clang__ is defined. This can easily happen when using clangd in vscode as clangd sets that define even if gcc is used to compile.

The current state of that line is invalid in C++11 or higher, as the name would be understood as a suffix, which isn't what you want here. Putting that space here shouldn't change the functionality in any version but make it valid code for newer C++ standards. 